### PR TITLE
Lift some typing requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ disableBytesTypePromotions = true
 reportAny = false
 reportImplicitStringConcatenation = false
 reportUnreachable = "information"
-reportMissingTypeStubs = "information"
+reportMissingTypeStubs = false
 reportUninitializedInstanceVariable = false # until https://github.com/DetachHead/basedpyright/issues/491
 reportMissingParameterType = false          # ruff's flake8-annotations (ANN) already covers this + gives us more control
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,9 @@ reportMissingTypeStubs = false
 reportUninitializedInstanceVariable = false # until https://github.com/DetachHead/basedpyright/issues/491
 reportMissingParameterType = false          # ruff's flake8-annotations (ANN) already covers this + gives us more control
 
+# Too strict for py-cord codebases
+reportIncompatibleMethodOverride = false
+
 # Unknown type reporting rules (too strict for most code-bases)
 reportUnknownArgumentType = false
 reportUnknownVariableType = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ reportMissingParameterType = false          # ruff's flake8-annotations (ANN) al
 
 # Too strict for py-cord codebases
 reportIncompatibleMethodOverride = false
+reportUnusedCallResult = false
 
 # Unknown type reporting rules (too strict for most code-bases)
 reportUnknownArgumentType = false

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -26,7 +26,7 @@ async def main() -> None:
     This will load all of the extensions and start the bot.
     """
     log.info("Loading extensions...")
-    _ = bot.load_extensions(*EXTENSIONS)
+    bot.load_extensions(*EXTENSIONS)
 
     log.info("Starting the bot...")
     async with bot:

--- a/src/exts/ping/ping.py
+++ b/src/exts/ping/ping.py
@@ -14,7 +14,7 @@ class PingCog(Cog):
     @slash_command()
     async def ping(self, ctx: ApplicationContext) -> None:
         """Test out bot's latency."""
-        _ = await ctx.respond(f"Pong! ({(self.bot.latency * 1000):.2f}ms)")
+        await ctx.respond(f"Pong! ({(self.bot.latency * 1000):.2f}ms)")
 
 
 def setup(bot: Bot) -> None:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, NewType, TYPE_CHECKING, TypeVar, cast, overload
 
-from decouple import UndefinedValueError, config  # pyright: ignore[reportMissingTypeStubs]
+from decouple import UndefinedValueError, config
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/src/utils/log.py
+++ b/src/utils/log.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Any, TYPE_CHECKING, cast
 
-import coloredlogs  # pyright: ignore[reportMissingTypeStubs]
+import coloredlogs
 
 from src.utils.config import get_config
 


### PR DESCRIPTION
This reduces the typing requirements enforced by the type-checker, to make work a bit more feasible within py-cord codebase, considering the framework's typing support isn't as good as I originally assumed. 