### PR TITLE
Add sudo / debug cog

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -10,6 +10,7 @@ log = get_logger(__name__)
 EXTENSIONS = [
     "src.exts.ping",
     "src.exts.error_handler",
+    "src.exts.sudo",
 ]
 
 intents = discord.Intents().default()

--- a/src/converters/bot_extension.py
+++ b/src/converters/bot_extension.py
@@ -1,0 +1,42 @@
+import importlib
+import inspect
+from typing import override
+
+from discord.ext.commands import Bot, Context, Converter
+
+
+class ValidBotExtension(Converter[str]):
+    """Convert given extension name to a fully qualified path to extension."""
+
+    @staticmethod
+    def valid_extension_path(extension_name: str) -> str:
+        """Get the fully qualified path to a valid bot extension.
+
+        The `extension_name` can be:
+        - A fully qualified path (e.g. 'src.exts.ping'),
+        - A suffix component of a fully qualified path (e.g. 'exts.ping', or just 'ping')
+
+          The suffix must still be an entire path component, so while 'ping' is valid, 'pi' or 'ng' is not.
+
+        If the `extension_name` doesn't point to a valid extension a ValueError will be raised.
+        """
+        extension_name = extension_name.removeprefix("src.exts.").removeprefix("exts.")
+        extension_name = f"src.exts.{extension_name}"
+
+        # This could technically be a vulnerability, but this converter can only
+        # be used by the bot owner
+        try:
+            imported = importlib.import_module(extension_name)
+        except ModuleNotFoundError:
+            raise ValueError(f"Unable to import '{extension_name}'.")
+
+        # If it lacks a setup function, it's not an extension
+        if not inspect.isfunction(getattr(imported, "setup", None)):
+            raise ValueError(f"'{extension_name}' is not a valid extension.")
+
+        return extension_name
+
+    @override
+    async def convert(self, ctx: Context[Bot], argument: str) -> str:
+        """Try to match given `argument` to a valid extension within the bot project."""
+        return self.valid_extension_path(argument)

--- a/src/exts/sudo/__init__.py
+++ b/src/exts/sudo/__init__.py
@@ -1,0 +1,3 @@
+from .sudo import setup
+
+__all__ = ["setup"]

--- a/src/exts/sudo/sudo.py
+++ b/src/exts/sudo/sudo.py
@@ -1,0 +1,83 @@
+from typing import cast, override
+
+from discord import (
+    ApplicationContext,
+    Bot,
+    Cog,
+    ExtensionAlreadyLoaded,
+    ExtensionNotLoaded,
+    SlashCommandGroup,
+    User,
+    option,
+)
+from discord.ext.commands.errors import NotOwner
+
+from src.converters.bot_extension import ValidBotExtension
+
+
+class Sudo(Cog):
+    """Cog that allows the bot owner to perform various privileged actions."""
+
+    def __init__(self, bot: Bot) -> None:
+        self.bot = bot
+
+    sudo = SlashCommandGroup(name="sudo", description="Commands for the bot owner.")
+
+    @sudo.command()
+    @option("extension", ValidBotExtension)
+    async def load(self, ctx: ApplicationContext, extension: str) -> None:
+        """Dynamically load a requested bot extension.
+
+        This can be very useful for debugging and testing new features without having to restart the bot.
+        """
+        try:
+            self.bot.load_extension(extension)
+        except ExtensionAlreadyLoaded:
+            await ctx.respond("❌ Extension is already loaded")
+            return
+        await ctx.respond(f"✅ Extension `{extension}` loaded")
+
+    @sudo.command()
+    @option("extension", ValidBotExtension)
+    async def unload(self, ctx: ApplicationContext, extension: str) -> None:
+        """Dynamically unload a requested bot extension.
+
+        This can be very useful for debugging and testing new features without having to restart the bot.
+        """
+        try:
+            self.bot.unload_extension(extension)
+        except ExtensionNotLoaded:
+            await ctx.respond("❌ Extension is not loaded")
+            return
+        await ctx.respond(f"✅ Extension `{extension}` unloaded")
+
+    @sudo.command()
+    @option("extension", ValidBotExtension)
+    async def reload(self, ctx: ApplicationContext, extension: str) -> None:
+        """Dynamically reload a requested bot extension.
+
+        This can be very useful for debugging and testing new features without having to restart the bot.
+        """
+        try:
+            self.bot.unload_extension(extension)
+        except ExtensionNotLoaded:
+            already_loaded = False
+        else:
+            already_loaded = True
+        self.bot.load_extension(extension)
+
+        action = "reloaded" if already_loaded else "loaded"
+        await ctx.respond(f"✅ Extension `{extension}` {action}")
+
+    @override
+    async def cog_check(self, ctx: ApplicationContext) -> bool:
+        """Only the bot owners can use this cog."""
+        if not await self.bot.is_owner(cast(User, ctx.author)):
+            raise NotOwner
+
+        return super().cog_check(ctx)
+
+
+def setup(bot: Bot) -> None:
+    """Load the Reloader cog."""
+    bot.add_cog(Sudo(bot))


### PR DESCRIPTION
Adds an extension that allows the bot owner to quickly dynamically reload extensions. This makes it a lot nicer to test out changes in extensions when debugging / adding features without having to completely restart the bot.

Restarting too often can also cause issues with hitting rate-limits, this avoids that too