### PR TITLE
Suppress some spammy py-cord logs

### DIFF
--- a/src/utils/log.py
+++ b/src/utils/log.py
@@ -192,6 +192,8 @@ def _setup_external_log_levels(root_log: LoggerClass) -> None:
     set explicitly here, avoiding unneeded spammy logs.
     """
     get_logger("asyncio").setLevel(logging.INFO)
+    get_logger("discord.http").setLevel(logging.INFO)
+    get_logger("discord.gateway").setLevel(logging.WARNING)
     get_logger("aiosqlite").setLevel(logging.INFO)
     get_logger("alembic.runtime.migration").setLevel(logging.WARNING)
 


### PR DESCRIPTION
When running with `DEBUG=0` this isn't a problem, but with `DEBUG=1`, these py-cord loggers produce a LOT of output. We're not really interested in seeing this and it mostly just clutters our actually useful internal debug logs. This therefore explicitly drops the log level on these loggers to INFO or even WARNING.

Note:
Another option would be to suppress all `discord` loggers completely, at least down to INFO, rather than focusing on the very spammy ones. I'm not sure this is a good idea, since some of the logs are pretty nice to see, like the `discord.client` ones, producing a log whenever an event occurs.