### PR TITLE
Fix alembic auto-migrations

### DIFF
--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from typing import NoReturn
 
 import alembic.config
+from alembic.operations import Operations
 from alembic.runtime.environment import EnvironmentContext
 from alembic.runtime.migration import MigrationContext, RevisionStep
 from alembic.script import ScriptDirectory
@@ -110,7 +111,7 @@ def apply_db_migrations(db_conn: Connection) -> None:
         return
 
     log.debug("Checking for database migrations")
-    with context.begin_transaction():
+    with Operations.context(context) as _op, context.begin_transaction():
         context.run_migrations()
 
 


### PR DESCRIPTION
Closes #61

The issue here was that Alembic didn't patch an operations instance, which meant the operations in `from alembic import op` weren't able to run successfully. (Alembic does this weird thing where the operations are all added to the globals dynamically with a Operations instance being proxied by patching it first, it's really weird and complex...)

*Such small change, yet so annoying to figure out*

(The reason i didn't catch this in #35 is because I only tested it with empty migration files that didn't actually do anything.)